### PR TITLE
Add 1/4" to vertical margins to fix trim issue

### DIFF
--- a/obs/export.py
+++ b/obs/export.py
@@ -104,8 +104,8 @@ def checkForStandardKeysJSON():
     global body_json # Cannot pass dictionary via regex framework
     #------------------------------  header/footer spacing and body font-face
     if 'textwidth' not in body_json.keys(): body_json['textwidth'] = '308.9pt' # At 72.27 pt/inch this is width of each figure
-    if 'topspace' not in body_json.keys(): body_json['topspace'] = '10pt' # nice for en,fr,es
-    if 'botspace' not in body_json.keys(): body_json['botspace'] = '12pt' # nice for en,fr,es
+    if 'topspace' not in body_json.keys(): body_json['topspace'] = '28pt' # nice for en,fr,es
+    if 'botspace' not in body_json.keys(): body_json['botspace'] = '30pt' # nice for en,fr,es
     #if 'fontface' not in body_json.keys(): body_json['fontface'] = 'dejavu' # this is for production but does not seem to work for Russian
     if 'fontface' not in body_json.keys(): body_json['fontface'] = 'noto'
     if 'fontstyle' not in body_json.keys(): body_json['fontstyle'] = 'sans' # this is for production but does not seem to work for Russian

--- a/obs/export.py
+++ b/obs/export.py
@@ -105,7 +105,7 @@ def checkForStandardKeysJSON():
     #------------------------------  header/footer spacing and body font-face
     if 'textwidth' not in body_json.keys(): body_json['textwidth'] = '308.9pt' # At 72.27 pt/inch this is width of each figure
     if 'topspace' not in body_json.keys(): body_json['topspace'] = '28pt' # nice for en,fr,es
-    if 'botspace' not in body_json.keys(): body_json['botspace'] = '30pt' # nice for en,fr,es
+    if 'botspace' not in body_json.keys(): body_json['botspace'] = '28pt' # nice for en,fr,es
     #if 'fontface' not in body_json.keys(): body_json['fontface'] = 'dejavu' # this is for production but does not seem to work for Russian
     if 'fontface' not in body_json.keys(): body_json['fontface'] = 'noto'
     if 'fontstyle' not in body_json.keys(): body_json['fontstyle'] = 'sans' # this is for production but does not seem to work for Russian

--- a/obs/tex/main_template.tex
+++ b/obs/tex/main_template.tex
@@ -31,8 +31,8 @@
 \setuppagenumbering[location={footer,middle}, conversion=numbers,strut=yes,style=\tfxx]
 \setupitemize[1][leftmargin=18.0pt,rightmargin=18.0pt]
 \setuplayout[width=fit,backspace=36pt,
-    topspace=36pt,
-    bottomspace=36pt,
+    topspace=28pt,
+    bottomspace=28pt,
     header=0pt,
     height=fit,
     width=<<<[textwidth]>>>,

--- a/obs/tex/main_template.tex
+++ b/obs/tex/main_template.tex
@@ -160,7 +160,7 @@
     \setupinterlinespace[line=<<<[bodybaseline]>>>,top=0.0,bottom=0.0] % Line spacing
     \saveskip=\baselineskip
     \savesize=\bodyfontsize
-    \MiscTare=\dimexpr \topspace + \bottomspace + 28pt \relax
+    \MiscTare=\dimexpr \topspace + \bottomspace \relax
     \setupfooter [state=start]
     ===CHAPTERS===
 \stopbodymatter % The stories themselves


### PR DESCRIPTION
This is in response to [a request][1] in the Slack #publishing channel.
It increases both the top and bottom margins by 1/4" (18 points) to
accommodate a larger trim size.

 [1]: https://team43.slack.com/archives/publishing/p1443790117000044